### PR TITLE
Add 'meta' property on linked data object

### DIFF
--- a/src/model/model-linker/model-linker.js
+++ b/src/model/model-linker/model-linker.js
@@ -24,7 +24,7 @@
         return null;
       }
 
-      return {type: object.data.type, id: object.data.id};
+      return {type: object.data.type, id: object.data.id, meta: object.meta};
     }
 
     /**


### PR DESCRIPTION
Sometimes, it's necessary to send additional data on a relationship (a field's name, etc...) in order to be processed by JSON API backend. The spec says META property is optional.
