### PR TITLE
adding a more complete ignores section

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,14 @@
   },
   "ignore": [
     "demo/",
-    "demo-dist/"
+    "demo-dist/",
+    "gulp",
+    "src",
+    "**/.*",
+    "gulpfile.js",
+    "karma.conf.js",
+    "package.json",
+    "protractor.conf.js"
   ],
   "devDependencies": {
     "angular-recursion": "~1.0.5",


### PR DESCRIPTION
This fixes Issue #43.

Now removing:
- `gulp` and `src` directories
- any `.*` file across the repo
- `package.json`
- `gulp`, `karma` and `protractor` setup files
