### PR TITLE
Fix CodeClimate.yml pulling in minified scripts (now recursive)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,10 +1,10 @@
 languages:
    JavaScript: true
 exclude_paths:
-- "dist/*"
-- "dist-demo/*"
-- "demo/*"
-- "gulp/*"
+- "dist/**/*"
+- "dist-demo/**/*"
+- "demo/**/*"
+- "gulp/**/*"
 - "karma.conf.js"
 - "gulpfile.js"
 - "protractor.conf.js"


### PR DESCRIPTION
I noticed that some files were causing issues in `/dist-demo/` and realized that the .codeclimate.yml wasn't recursively blocking dist, dist-demo, and demo. I took a minute to update it, and confirmed that those are not being pulled into code climate any longer.

Here are the "F" results for the [jakubrohleder/angular-jsonapit (286 Fs)](https://codeclimate.com/github/jakubrohleder/angular-jsonapi/code?q=rating%3AF) and. [etkirsch/angular-json-api (31 Fs)](https://codeclimate.com/github/etkirsch/angular-jsonapi/code?q=rating%3AF) repositories. 
